### PR TITLE
Bump version for the casting error bugfix.

### DIFF
--- a/lib/sensu-plugins-elasticsearch/version.rb
+++ b/lib/sensu-plugins-elasticsearch/version.rb
@@ -2,7 +2,7 @@ module SensuPluginsElasticsearch
   module Version
     MAJOR = 0
     MINOR = 1
-    PATCH = 3
+    PATCH = 4
 
     VER_STRING = [MAJOR, MINOR, PATCH].compact.join('.')
   end


### PR DESCRIPTION
Create a new release for this gem such that we can use it in application
stacks.  (In particular we need it for sensu-deploy)

This work should be part of 1763da1b817 but was missed off.
