### PR TITLE
(WIP) Add ignore NaN option to check-es-data

### DIFF
--- a/bin/check-es-data.rb
+++ b/bin/check-es-data.rb
@@ -32,6 +32,9 @@ OptionParser.new do |opts|
           'ElasticSearch URL, Example: https://elasticsearch.example.com/es/_all/_search') do |l|
     options[:elasticsearch_location] = l
   end
+  opts.on('--ignore-nan DEFAULT_VALUE', 'When NaN is returned convert it to the number specified') do |f|
+    options[:ignore_nan] = f.to_f
+  end
 end.parse!
 
 # It would be nice if OptionParser had a way to mandate options
@@ -93,7 +96,9 @@ end
 if value.is_a?(NilClass) && options[:nil]
   value = 0
 end
-
+if not value.is_a? Numeric and options[:ignore_nan]
+  value = options[:ignore_nan]
+end
 unless value.is_a?(Float) || value.is_a?(Integer)
   puts "UNKNOWN: query returned a value of #{value} (type: #{value.class}) - was expecting an Integer or Float"
   exit 3


### PR DESCRIPTION
In some cases we get NaN back from our check but this is not
necessarily a sign of failure. Such as the case where we calculate
an aggregation when no data exists. By adding --ignore-nan we can
explicitly set the return to be a default number.
