### PR TITLE
Handle NaN aggregation results when we have no results

### DIFF
--- a/bin/check-es-data.rb
+++ b/bin/check-es-data.rb
@@ -79,6 +79,11 @@ end
 # If aggregration is in place then just the first value (as specified in the query) is returned
 if json.key? 'aggregations'
   value = first_aggregation_value(json['aggregations'])
+    # If we get a value of NaN for aggregations because we have no results to
+    # aggregate, we return zero instead
+   if value == 'NaN' && json['hits']['total'] == 0
+     value = 0
+   end
 elsif json.key? 'hits'
   value = json['hits']['total']
 else


### PR DESCRIPTION
When we have no results from our search and aggregate, we end
up with a NaN value. This breaks the query. This change checks to
see if we have NaN, and that also we have no hits, and zeroes this
result. Cases where we have NaN but have hits will still break the
query.
